### PR TITLE
Workaround for the symbol conflicts of 'DictIterateCaller'

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -2,6 +2,8 @@
 #include <vector>
 #include <algorithm>
 
+namespace ScriptEx {
+
 /**
  * メソッド追加用
  */
@@ -745,6 +747,11 @@ ScriptsExAdd::safeEvalStorage(tTJSVariant *result,
 
 	return TJS_S_OK;
 }
+
+};
+
+using ScriptsExAdd = ScriptEx::ScriptsExAdd;
+
 //----------------------------------------------------------------------
 NCB_ATTACH_CLASS(ScriptsExAdd, Scripts) {
 	RawCallback(TJS_W("getObjectKeys"), &ScriptsExAdd::getKeys, TJS_STATICMEMBER);


### PR DESCRIPTION
The DictIterateCaller symbol conflicts with that of external/ksupport/utils.cpp, whose memory layout is different. This workaround will solve crashes on `Script.forEach`.